### PR TITLE
Fixed the tag for the Subtitles on MediaInf

### DIFF
--- a/src/main/java/com/comcast/viper/hlsparserj/tags/master/StreamInf.java
+++ b/src/main/java/com/comcast/viper/hlsparserj/tags/master/StreamInf.java
@@ -119,7 +119,7 @@ public class StreamInf extends Tag {
     private static final String RESOLUTION = "RESOLUTION";
     private static final String AUDIO = "AUDIO";
     private static final String VIDEO = "VIDEO";
-    private static final String SUBTITLE = "SUBTITLE";
+    private static final String SUBTITLE = "SUBTITLES";
     private static final String CLOSEDCAPTIONS = "CLOSEDCAPTIONS";
 
     /**


### PR DESCRIPTION
Based on the url reference, https://tools.ietf.org/html/rfc8216, the tag for the SUBTITLES must be plural, but in MediaInf is singular (SUBTITLE), causing not returning the correct element. Because of this, the missing S was added.